### PR TITLE
Re-arrange custom types

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-state-types/manifest"
-	"github.com/filecoin-project/lotus/api"
 	filTypes "github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
 	rosettaFilecoinLib "github.com/zondax/rosetta-filecoin-lib"
@@ -30,7 +29,7 @@ func NewParser(lib *rosettaFilecoinLib.RosettaConstructionFilecoin) *Parser {
 	}
 }
 
-func (p *Parser) ParseTransactions(traces []*api.InvocResult, tipSet *filTypes.TipSet, ethLogs []types.EthLog) ([]*types.Transaction, *types.AddressInfoMap, error) {
+func (p *Parser) ParseTransactions(traces []*types.InvocResult, tipSet *filTypes.TipSet, ethLogs []types.EthLog) ([]*types.Transaction, *types.AddressInfoMap, error) {
 	var transactions []*types.Transaction
 	p.addresses = types.NewAddressInfoMap()
 	tipsetKey := tipSet.Key()
@@ -68,7 +67,7 @@ func (p *Parser) ParseTransactions(traces []*api.InvocResult, tipSet *filTypes.T
 	return transactions, &p.addresses, nil
 }
 
-func (p *Parser) parseSubTxs(subTxs []filTypes.ExecutionTrace, mainMsgCid cid.Cid, tipSet *filTypes.TipSet, ethLogs []types.EthLog, blockHash, txHash string,
+func (p *Parser) parseSubTxs(subTxs []types.ExecutionTrace, mainMsgCid cid.Cid, tipSet *filTypes.TipSet, ethLogs []types.EthLog, blockHash, txHash string,
 	key filTypes.TipSetKey, level uint16) (txs []*types.Transaction) {
 
 	level++
@@ -84,7 +83,7 @@ func (p *Parser) parseSubTxs(subTxs []filTypes.ExecutionTrace, mainMsgCid cid.Ci
 	return
 }
 
-func (p *Parser) parseTrace(trace filTypes.ExecutionTrace, msgCid cid.Cid, tipSet *filTypes.TipSet, ethLogs []types.EthLog, blockHash string,
+func (p *Parser) parseTrace(trace types.ExecutionTrace, msgCid cid.Cid, tipSet *filTypes.TipSet, ethLogs []types.EthLog, blockHash string,
 	key filTypes.TipSetKey) (*types.Transaction, error) {
 	txType, err := p.GetMethodName(trace.Msg, int64(tipSet.Height()), key)
 	if err != nil {
@@ -128,7 +127,7 @@ func (p *Parser) parseTrace(trace filTypes.ExecutionTrace, msgCid cid.Cid, tipSe
 	}, nil
 }
 
-func (p *Parser) feesTransactions(msg *api.InvocResult, minerAddress, txHash, blockHash, txType string, height uint64, timestamp uint64) *types.Transaction {
+func (p *Parser) feesTransactions(msg *types.InvocResult, minerAddress, txHash, blockHash, txType string, height uint64, timestamp uint64) *types.Transaction {
 	ts := p.getTimestamp(timestamp)
 	metadata := FeesMetadata{
 		TxType: txType,
@@ -150,7 +149,7 @@ func (p *Parser) feesTransactions(msg *api.InvocResult, minerAddress, txHash, bl
 	return feeTx
 }
 
-func (p *Parser) newFeeTx(msg *api.InvocResult, txHash, blockHash string, height uint64,
+func (p *Parser) newFeeTx(msg *types.InvocResult, txHash, blockHash string, height uint64,
 	timestamp time.Time, feesMetadata FeesMetadata) *types.Transaction {
 	metadata, _ := json.Marshal(feesMetadata)
 
@@ -170,7 +169,7 @@ func (p *Parser) newFeeTx(msg *api.InvocResult, txHash, blockHash string, height
 
 }
 
-func hasMessage(trace *api.InvocResult) bool {
+func hasMessage(trace *types.InvocResult) bool {
 	return trace.Msg != nil
 }
 

--- a/types/compute_state.go
+++ b/types/compute_state.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/ipfs/go-cid"
+	"time"
+)
+
+type FilteredeComputeStateOutput struct {
+	Root  cid.Cid
+	Trace []*InvocResult
+}
+
+type InvocResult struct {
+	MsgCid         cid.Cid
+	Msg            *types.Message
+	MsgRct         *types.MessageReceipt
+	GasCost        api.MsgGasCost
+	Error          string
+	Duration       time.Duration
+	ExecutionTrace ExecutionTrace
+}
+
+type ExecutionTrace struct {
+	Msg        *types.Message
+	MsgRct     *types.MessageReceipt
+	Error      string
+	Duration   time.Duration
+	GasCharges []*types.GasTrace `json:"-"` // Ignoring this field increases the performance of the json unmarshalling
+
+	Subcalls []ExecutionTrace
+}

--- a/types/extended_tipset.go
+++ b/types/extended_tipset.go
@@ -1,0 +1,64 @@
+package types
+
+import (
+	"encoding/json"
+	lotusChainTypes "github.com/filecoin-project/lotus/chain/types"
+)
+
+type LightBlockHeader struct {
+	Cid        string
+	BlockMiner string
+}
+
+type BlockMessages map[string][]LightBlockHeader // map[MessageCid][]LightBlockHeader
+
+type ExtendedTipSet struct {
+	lotusChainTypes.TipSet
+	BlockMessages
+}
+
+func (e *ExtendedTipSet) MarshalJSON() ([]byte, error) {
+	data, err := json.Marshal(&struct {
+		lotusChainTypes.ExpTipSet
+		BlockMessages
+	}{
+		ExpTipSet: lotusChainTypes.ExpTipSet{
+			Cids:   e.TipSet.Cids(),
+			Blocks: e.TipSet.Blocks(),
+			Height: e.TipSet.Height(),
+		},
+		BlockMessages: e.BlockMessages,
+	})
+
+	return data, err
+}
+
+func (e *ExtendedTipSet) UnmarshalJSON(data []byte) error {
+	auxTipset := &struct {
+		lotusChainTypes.TipSet
+	}{}
+
+	if err := json.Unmarshal(data, &auxTipset); err != nil {
+		// try other way
+		auxTipset := &struct {
+			Tipset lotusChainTypes.TipSet
+		}{}
+
+		if err := json.Unmarshal(data, &auxTipset); err != nil {
+			return err
+		}
+		e.TipSet = auxTipset.Tipset
+	} else {
+		e.TipSet = auxTipset.TipSet
+	}
+
+	auxMessages := &struct {
+		BlockMessages
+	}{}
+	if err := json.Unmarshal(data, &auxMessages); err != nil {
+		return err
+	}
+
+	e.BlockMessages = auxMessages.BlockMessages
+	return nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -1,11 +1,9 @@
 package types
 
 import (
-	"encoding/json"
 	"math/big"
 	"time"
 
-	lotusChainTypes "github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/ethtypes"
 	"github.com/ipfs/go-cid"
 )
@@ -72,32 +70,4 @@ type Transaction struct {
 	TxParams string `json:"tx_params"`
 	// TxReturn contains the returned data by the destination actor
 	TxReturn string `json:"tx_return"`
-}
-
-type LightBlockHeader struct {
-	Cid        string
-	BlockMiner string
-}
-
-type BlockMessages map[string][]LightBlockHeader // map[MessageCid][]LightBlockHeader
-
-type ExtendedTipSet struct {
-	lotusChainTypes.TipSet
-	BlockMessages
-}
-
-func (e *ExtendedTipSet) MarshalJSON() ([]byte, error) {
-	data, err := json.Marshal(&struct {
-		lotusChainTypes.ExpTipSet
-		BlockMessages
-	}{
-		ExpTipSet: lotusChainTypes.ExpTipSet{
-			Cids:   e.TipSet.Cids(),
-			Blocks: e.TipSet.Blocks(),
-			Height: e.TipSet.Height(),
-		},
-		BlockMessages: e.BlockMessages,
-	})
-
-	return data, err
 }


### PR DESCRIPTION
- All this reaccommodation is to be able to avoid unmarshalling the `[]GasCharges` inside the `ExecutionTraces`