### PR TITLE
Block cid minor fix

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -40,7 +40,7 @@ func BuildFeeId(tipsetCid, blockCid, messageCid string) string {
 
 func GetBlockCidFromMsgCid(msgCid, txType string, txMetadata map[string]interface{}, tipset *types.ExtendedTipSet) (string, error) {
 	// Default value
-	blockCid := tipset.GetCidString()
+	blockCid := ""
 
 	// Process the special cases first were this kind of txs are not explicitly included in a block
 	switch txType {


### PR DESCRIPTION
Use empty block_cid if tx doesn't belong to a specific block