### PR TITLE
Fix tx parsing for placeholder actor type

### DIFF
--- a/actors/actor.go
+++ b/actors/actor.go
@@ -30,18 +30,7 @@ func (p *ActorParser) GetMetadata(txType string, msg *parser.LotusMessage, mainM
 		return metadata, nil, nil
 	}
 
-	actorCode, err := p.helper.GetActorsCache().GetActorCode(msg.To, key)
-	if err != nil {
-		return metadata, nil, err
-	}
-
-	c, err := cid.Parse(actorCode)
-	if err != nil {
-		p.logger.Sugar().Errorf("Could not parse actor code: %v", err)
-		return metadata, nil, err
-	}
-
-	actor, err := p.helper.GetFilecoinLib().BuiltinActors.GetActorNameFromCid(c)
+	actor, err := p.helper.GetActorNameFromAddress(msg.To, height, key)
 	if err != nil {
 		return metadata, nil, err
 	}

--- a/actors/actor.go
+++ b/actors/actor.go
@@ -68,14 +68,15 @@ func (p *ActorParser) GetMetadata(txType string, msg *parser.LotusMessage, mainM
 		metadata, err = p.ParseReward(txType, msg, msgRct)
 	case manifest.VerifregKey:
 		metadata, err = p.ParseVerifiedRegistry(txType, msg, msgRct)
-	case manifest.EvmKey, manifest.EthAccountKey:
+	case manifest.EvmKey:
 		metadata, err = p.ParseEvm(txType, msg, mainMsgCid, msgRct, ethLogs)
 	case manifest.EamKey:
 		metadata, addressInfo, err = p.ParseEam(txType, msg, msgRct, mainMsgCid)
 	case manifest.DatacapKey:
 		metadata, err = p.ParseDatacap(txType, msg, msgRct)
-	case manifest.PlaceholderKey:
-		err = nil // placeholder has no methods
+	case manifest.PlaceholderKey, manifest.EthAccountKey:
+		// placeholder and ethaccount can only receive tokens by Send or InvokeEVM methods
+		err = nil
 	default:
 		err = parser.ErrNotValidActor
 	}

--- a/actors/cache/actors_cache.go
+++ b/actors/cache/actors_cache.go
@@ -66,21 +66,23 @@ func (a *ActorsCache) ClearBadAddressCache() {
 	a.badAddress.Clear()
 }
 
-func (a *ActorsCache) GetActorCode(add address.Address, key filTypes.TipSetKey) (string, error) {
+func (a *ActorsCache) GetActorCode(add address.Address, key filTypes.TipSetKey, onChainOnly bool) (string, error) {
 	// Check if this address is flagged as bad
 	if a.isBadAddress(add) {
 		return "", fmt.Errorf("address %s is flagged as bad", add.String())
 	}
 
-	// Try kv store cache
-	actorCode, err := a.offlineCache.GetActorCode(add, key)
-	if err == nil {
-		return actorCode, nil
+	if !onChainOnly {
+		// Try kv store cache
+		actorCode, err := a.offlineCache.GetActorCode(add, key)
+		if err == nil {
+			return actorCode, nil
+		}
 	}
 
 	a.logger.Sugar().Debugf("[ActorsCache] - Unable to retrieve actor code from offline cache for address %s. Trying on-chain cache", add.String())
 	// Try on-chain cache
-	actorCode, err = a.onChainCache.GetActorCode(add, key)
+	actorCode, err := a.onChainCache.GetActorCode(add, key)
 	if err != nil {
 		a.logger.Sugar().Error("[ActorsCache] - Unable to retrieve actor code from node: %s", err.Error())
 		if strings.Contains(err.Error(), "actor not found") {

--- a/actors/multisig.go
+++ b/actors/multisig.go
@@ -168,7 +168,7 @@ func (p *ActorParser) parseMsigParams(msg *parser.LotusMessage, height int64, ke
 		return "", err
 	}
 
-	actorCode, err := p.helper.GetActorsCache().GetActorCode(msg.To, key)
+	actorCode, err := p.helper.GetActorsCache().GetActorCode(msg.To, key, false)
 	if err != nil {
 		return "", err
 	}

--- a/factory.go
+++ b/factory.go
@@ -140,8 +140,8 @@ func (p *FilecoinParser) ParseGenesis(genesis *types.GenesisBalances, genesisTip
 		filAdd, _ := address.NewFromString(balance.Key)
 		shortAdd, _ := p.Helper.GetActorsCache().GetShortAddress(filAdd)
 		robustAdd, _ := p.Helper.GetActorsCache().GetRobustAddress(filAdd)
-		actorCode, _ := p.Helper.GetActorsCache().GetActorCode(filAdd, types2.EmptyTSK)
-		actorName := p.Helper.GetActorNameFromAddress(filAdd, 0, types2.EmptyTSK)
+		actorCode, _ := p.Helper.GetActorsCache().GetActorCode(filAdd, types2.EmptyTSK, false)
+		actorName, _ := p.Helper.GetActorNameFromAddress(filAdd, 0, types2.EmptyTSK)
 
 		addresses.Set(balance.Key, &types.AddressInfo{
 			Short:     shortAdd,

--- a/parser/helper/helpers.go
+++ b/parser/helper/helpers.go
@@ -32,20 +32,25 @@ import (
 )
 
 var allMethods = map[string]map[abi.MethodNum]builtin.MethodMeta{
-	manifest.InitKey:       filInit.Methods,
-	manifest.CronKey:       cron.Methods,
-	manifest.AccountKey:    account.Methods,
-	manifest.PowerKey:      power.Methods,
-	manifest.MinerKey:      miner.Methods,
-	manifest.MarketKey:     market.Methods,
-	manifest.PaychKey:      paych.Methods,
-	manifest.MultisigKey:   multisig.Methods,
-	manifest.RewardKey:     reward.Methods,
-	manifest.VerifregKey:   verifreg.Methods,
-	manifest.EvmKey:        evm.Methods,
-	manifest.EamKey:        eam.Methods,
-	manifest.DatacapKey:    datacap.Methods,
-	manifest.EthAccountKey: evm.Methods, // investigate this bafy2bzacebj3i5ehw2w6veowqisj2ag4wpp25glmmfsvejbwjj2e7axavonm6
+	manifest.InitKey:     filInit.Methods,
+	manifest.CronKey:     cron.Methods,
+	manifest.AccountKey:  account.Methods,
+	manifest.PowerKey:    power.Methods,
+	manifest.MinerKey:    miner.Methods,
+	manifest.MarketKey:   market.Methods,
+	manifest.PaychKey:    paych.Methods,
+	manifest.MultisigKey: multisig.Methods,
+	manifest.RewardKey:   reward.Methods,
+	manifest.VerifregKey: verifreg.Methods,
+	manifest.EvmKey:      evm.Methods,
+	manifest.EamKey:      eam.Methods,
+	manifest.DatacapKey:  datacap.Methods,
+
+	// EthAccount and Placeholder can receive tokens with Send and InvokeEVM methods
+	// We set evm.Methods instead of empty array of methods. Therefore, we will be able to understand
+	// this specific method (3844450837) - tx cid example: bafy2bzacedgmcvsp56ieciutvgwza2qpvz7pvbhhu4l5y5tdl35rwfnjn5buk
+	manifest.PlaceholderKey: evm.Methods,
+	manifest.EthAccountKey:  evm.Methods,
 }
 
 type Helper struct {


### PR DESCRIPTION
A placeholder actor can then be converted to ethaccount or evm actor. That is why we need to ask always for the actor type on chain. Besides, a placeholder and ethaccount can execute method 0 (Send) and XXXX (InvokeEVM). We need to be able to handle both tx types. 