### PR TITLE
fix metadata parsing for placeholder and ethaccount actors

### DIFF
--- a/actors/actor.go
+++ b/actors/actor.go
@@ -63,9 +63,10 @@ func (p *ActorParser) GetMetadata(txType string, msg *parser.LotusMessage, mainM
 		metadata, addressInfo, err = p.ParseEam(txType, msg, msgRct, mainMsgCid)
 	case manifest.DatacapKey:
 		metadata, err = p.ParseDatacap(txType, msg, msgRct)
-	case manifest.PlaceholderKey, manifest.EthAccountKey:
-		// placeholder and ethaccount can only receive tokens by Send or InvokeEVM methods
-		err = nil
+	case manifest.EthAccountKey:
+		metadata, err = p.ParseEthAccount(txType, msg, msgRct)
+	case manifest.PlaceholderKey:
+		metadata, err = p.ParsePlaceholder(txType, msg, msgRct)
 	default:
 		err = parser.ErrNotValidActor
 	}

--- a/actors/ethaccount.go
+++ b/actors/ethaccount.go
@@ -1,0 +1,18 @@
+package actors
+
+import (
+	"github.com/zondax/fil-parser/parser"
+)
+
+func (p *ActorParser) ParseEthAccount(_ string, msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt) (map[string]interface{}, error) {
+	// ethaccount can only receive tokens by Send or InvokeEVM methods
+	return p.parseEthAccountAny(msg.Params, msgRct.Return)
+}
+
+func (p *ActorParser) parseEthAccountAny(rawParams, rawReturn []byte) (map[string]interface{}, error) {
+	metadata := make(map[string]interface{})
+	metadata[parser.ParamsKey] = rawParams
+	metadata[parser.ReturnKey] = rawReturn
+
+	return metadata, nil
+}

--- a/actors/placeholder.go
+++ b/actors/placeholder.go
@@ -1,0 +1,18 @@
+package actors
+
+import (
+	"github.com/zondax/fil-parser/parser"
+)
+
+func (p *ActorParser) ParsePlaceholder(_ string, msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt) (map[string]interface{}, error) {
+	// placeholder can only receive tokens by Send or InvokeEVM methods
+	return p.parsePlaceholderAny(msg.Params, msgRct.Return)
+}
+
+func (p *ActorParser) parsePlaceholderAny(rawParams, rawReturn []byte) (map[string]interface{}, error) {
+	metadata := make(map[string]interface{})
+	metadata[parser.ParamsKey] = rawParams
+	metadata[parser.ReturnKey] = rawReturn
+
+	return metadata, nil
+}


### PR DESCRIPTION
Metadata is not being returned as plain bytes, so we are losing the metadata completely on db.