### PR TITLE
Remove ethlogs from tx metadata

### DIFF
--- a/actors/actor.go
+++ b/actors/actor.go
@@ -24,7 +24,7 @@ func NewActorParser(helper *helper.Helper, logger *zap.Logger) *ActorParser {
 }
 
 func (p *ActorParser) GetMetadata(txType string, msg *parser.LotusMessage, mainMsgCid cid.Cid, msgRct *parser.LotusMessageReceipt,
-	height int64, key filTypes.TipSetKey, ethLogs []types.EthLog) (map[string]interface{}, *types.AddressInfo, error) {
+	height int64, key filTypes.TipSetKey) (map[string]interface{}, *types.AddressInfo, error) {
 	metadata := make(map[string]interface{})
 	if msg == nil {
 		return metadata, nil, nil
@@ -57,8 +57,7 @@ func (p *ActorParser) GetMetadata(txType string, msg *parser.LotusMessage, mainM
 		metadata, err = p.ParseReward(txType, msg, msgRct)
 	case manifest.VerifregKey:
 		metadata, err = p.ParseVerifiedRegistry(txType, msg, msgRct)
-	case manifest.EvmKey:
-		metadata, err = p.ParseEvm(txType, msg, mainMsgCid, msgRct, ethLogs)
+
 	case manifest.EamKey:
 		metadata, addressInfo, err = p.ParseEam(txType, msg, msgRct, mainMsgCid)
 	case manifest.DatacapKey:

--- a/actors/actor.go
+++ b/actors/actor.go
@@ -57,7 +57,8 @@ func (p *ActorParser) GetMetadata(txType string, msg *parser.LotusMessage, mainM
 		metadata, err = p.ParseReward(txType, msg, msgRct)
 	case manifest.VerifregKey:
 		metadata, err = p.ParseVerifiedRegistry(txType, msg, msgRct)
-
+	case manifest.EvmKey:
+		metadata, err = p.ParseEvm(txType, msg, msgRct)
 	case manifest.EamKey:
 		metadata, addressInfo, err = p.ParseEam(txType, msg, msgRct, mainMsgCid)
 	case manifest.DatacapKey:

--- a/actors/evm_test.go
+++ b/actors/evm_test.go
@@ -3,10 +3,11 @@ package actors
 import (
 	"encoding/hex"
 	"fmt"
+	"testing"
+
 	"github.com/filecoin-project/go-state-types/manifest"
 	"github.com/stretchr/testify/require"
 	"github.com/zondax/fil-parser/parser"
-	"testing"
 )
 
 func TestActorParser_evmWithParamsOrReturn(t *testing.T) {
@@ -108,7 +109,7 @@ func TestActorParser_invokeContract(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ethLogs)
 
-	got, err := p.invokeContract(rawParams, rawReturn, msg.Cid, ethLogs)
+	got, err := p.invokeContract(rawParams, rawReturn)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, got["Params"], "0x8381e182ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000008b21c7d96a349834dcfaddf871accda700b843e1")
@@ -130,7 +131,7 @@ func TestActorParser_invokeContractReadOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ethLogs)
 
-	got, err := p.invokeContract(rawParams, rawReturn, msg.Cid, ethLogs)
+	got, err := p.invokeContract(rawParams, rawReturn)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 }
@@ -151,7 +152,7 @@ func TestActorParser_invokeContract_whenCborUnmarshalFail(t *testing.T) {
 
 	hexParamsString := "70a082310000000000000000000000001a5ef7ef64e3fb12be3b43edd77819dc7f034b1f"
 	rawParams, _ := hex.DecodeString(hexParamsString)
-	got, err := p.invokeContract(rawParams, rawReturn, msg.Cid, ethLogs)
+	got, err := p.invokeContract(rawParams, rawReturn)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, got["Params"], "0x70a082310000000000000000000000001a5ef7ef64e3fb12be3b43edd77819dc7f034b1f")

--- a/parser/v1/parser.go
+++ b/parser/v1/parser.go
@@ -123,7 +123,7 @@ func (p *Parser) ParseTransactions(ctx context.Context, txsData types.TxsData) (
 		}
 
 		// Main transaction
-		transaction, err := p.parseTrace(trace.ExecutionTrace, trace.MsgCid, txsData.Tipset, txsData.EthLogs, uuid.Nil.String())
+		transaction, err := p.parseTrace(trace.ExecutionTrace, trace.MsgCid, txsData.Tipset, uuid.Nil.String())
 		if err != nil {
 			continue
 		}
@@ -206,7 +206,7 @@ func (p *Parser) parseSubTxs(subTxs []typesV1.ExecutionTraceV1, mainMsgCid cid.C
 	parentId string, level uint16) (txs []*types.Transaction) {
 	level++
 	for _, subTx := range subTxs {
-		subTransaction, err := p.parseTrace(subTx, mainMsgCid, tipSet, ethLogs, parentId)
+		subTransaction, err := p.parseTrace(subTx, mainMsgCid, tipSet, parentId)
 		if err != nil {
 			continue
 		}
@@ -218,7 +218,7 @@ func (p *Parser) parseSubTxs(subTxs []typesV1.ExecutionTraceV1, mainMsgCid cid.C
 	return
 }
 
-func (p *Parser) parseTrace(trace typesV1.ExecutionTraceV1, mainMsgCid cid.Cid, tipset *types.ExtendedTipSet, ethLogs []types.EthLog, parentId string) (*types.Transaction, error) {
+func (p *Parser) parseTrace(trace typesV1.ExecutionTraceV1, mainMsgCid cid.Cid, tipset *types.ExtendedTipSet, parentId string) (*types.Transaction, error) {
 	txType, err := p.helper.GetMethodName(&parser.LotusMessage{
 		To:     trace.Msg.To,
 		From:   trace.Msg.From,
@@ -242,7 +242,7 @@ func (p *Parser) parseTrace(trace typesV1.ExecutionTraceV1, mainMsgCid cid.Cid, 
 	}, mainMsgCid, &parser.LotusMessageReceipt{
 		ExitCode: trace.MsgRct.ExitCode,
 		Return:   trace.MsgRct.Return,
-	}, int64(tipset.Height()), tipset.Key(), ethLogs)
+	}, int64(tipset.Height()), tipset.Key())
 
 	if mErr != nil {
 		p.logger.Sugar().Warnf("Could not get metadata for transaction in height %s of type '%s': %s", tipset.Height().String(), txType, mErr.Error())

--- a/parser/v2/parser.go
+++ b/parser/v2/parser.go
@@ -84,7 +84,7 @@ func (p *Parser) ParseTransactions(_ context.Context, txsData types.TxsData) (*t
 		}
 
 		// Main transaction
-		transaction, err := p.parseTrace(trace.ExecutionTrace, trace.MsgCid, txsData.Tipset, txsData.EthLogs, uuid.Nil.String())
+		transaction, err := p.parseTrace(trace.ExecutionTrace, trace.MsgCid, txsData.Tipset, uuid.Nil.String())
 		if err != nil {
 			continue
 		}
@@ -203,7 +203,7 @@ func (p *Parser) parseSubTxs(subTxs []typesV2.ExecutionTraceV2, mainMsgCid cid.C
 	parentId string, level uint16) (txs []*types.Transaction) {
 	level++
 	for _, subTx := range subTxs {
-		subTransaction, err := p.parseTrace(subTx, mainMsgCid, tipSet, ethLogs, parentId)
+		subTransaction, err := p.parseTrace(subTx, mainMsgCid, tipSet, parentId)
 		if err != nil {
 			continue
 		}
@@ -215,7 +215,7 @@ func (p *Parser) parseSubTxs(subTxs []typesV2.ExecutionTraceV2, mainMsgCid cid.C
 	return
 }
 
-func (p *Parser) parseTrace(trace typesV2.ExecutionTraceV2, mainMsgCid cid.Cid, tipset *types.ExtendedTipSet, ethLogs []types.EthLog, parentId string) (*types.Transaction, error) {
+func (p *Parser) parseTrace(trace typesV2.ExecutionTraceV2, mainMsgCid cid.Cid, tipset *types.ExtendedTipSet, parentId string) (*types.Transaction, error) {
 	txType, err := p.helper.GetMethodName(&parser.LotusMessage{
 		To:     trace.Msg.To,
 		From:   trace.Msg.From,
@@ -239,7 +239,7 @@ func (p *Parser) parseTrace(trace typesV2.ExecutionTraceV2, mainMsgCid cid.Cid, 
 	}, mainMsgCid, &parser.LotusMessageReceipt{
 		ExitCode: trace.MsgRct.ExitCode,
 		Return:   trace.MsgRct.Return,
-	}, int64(tipset.Height()), tipset.Key(), ethLogs)
+	}, int64(tipset.Height()), tipset.Key())
 
 	if mErr != nil {
 		p.logger.Sugar().Warnf("Could not get metadata for transaction in height %s of type '%s': %s", tipset.Height().String(), txType, mErr.Error())


### PR DESCRIPTION
https://app.clickup.com/t/8694j0p3m

Now that the Event indexer handles both Native Logs and Eth Logs, we can remove them from the tx metadata to avoid duplicate data in the DB.

<!-- ClickUpRef: 8694p3c2q -->
:link: [zboto Link](https://app.clickup.com/t/8694p3c2q)