### PR TITLE
[FIX] Make genesis metadata valid JSON

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -240,6 +240,7 @@ func (p *FilecoinParser) ParseGenesis(genesis *types.GenesisBalances, genesisTip
 			Amount:      amount.Int,
 			Status:      "Ok",
 			TxType:      txType,
+			TxMetadata:  "{}",
 		})
 	}
 


### PR DESCRIPTION
https://app.clickup.com/t/2469579/8694vhmjd

We also need to re-upload the genesis_balances.json and genesis_tipset.json to the s3 buckets because of this error happening in all envs:

<img width="1423" alt="Screenshot 2024-07-15 at 17 52 36" src="https://github.com/user-attachments/assets/096a323a-b5df-4096-9573-8a0f729e89c6">


