### PR TITLE
Adds TxCid to genesis transactions

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -326,6 +326,7 @@ func (p *FilecoinParser) ParseGenesis(genesis *types.GenesisBalances, genesisTip
 			TxFrom:      parser.TxFromGenesis,
 			Amount:      amount.Int,
 			Status:      "Ok",
+			TxCid:       tipsetCid,
 			TxType:      txType,
 			TxMetadata:  "{}",
 		})


### PR DESCRIPTION
Includes the transaction CID (TxCid) when parsing genesis
transactions, providing more comprehensive data.
