### PR TITLE
Save created actor info only for successful txs

### DIFF
--- a/actors/v1/eam.go
+++ b/actors/v1/eam.go
@@ -18,18 +18,18 @@ import (
 )
 
 // TODO: do we need ethLogs?
-func (p *ActorParser) ParseEam(txType string, msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
+func (p *ActorParser) ParseEam(txType string, msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt, mainMsgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
 	metadata := make(map[string]interface{})
 	var err error
 	switch txType {
 	case parser.MethodConstructor:
 		metadata, err = p.emptyParamsAndReturn()
 	case parser.MethodCreate:
-		return p.parseCreate(msg.Params, msgRct.Return, msgCid)
+		return p.parseCreate(msg, msgRct, mainMsgCid)
 	case parser.MethodCreate2:
-		return p.parseCreate2(msg.Params, msgRct.Return, msgCid)
+		return p.parseCreate2(msg, msgRct, mainMsgCid)
 	case parser.MethodCreateExternal:
-		return p.parseCreateExternal(msg.Params, msgRct.Return, msgCid)
+		return p.parseCreateExternal(msg, msgRct, mainMsgCid)
 	case parser.UnknownStr:
 		metadata, err = p.unknownMetadata(msg.Params, msgRct.Return)
 	default:
@@ -77,10 +77,10 @@ func (p *ActorParser) newEamCreate(r eam.CreateReturn) parser.EamCreateReturn {
 	}
 }
 
-func (p *ActorParser) parseCreate(rawParams, rawReturn []byte, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
+func (p *ActorParser) parseCreate(msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt, mainMsgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
 	metadata := make(map[string]interface{})
 
-	reader := bytes.NewReader(rawParams)
+	reader := bytes.NewReader(msg.Params)
 	var params eam.CreateParams
 	err := params.UnmarshalCBOR(reader)
 	if err != nil {
@@ -88,13 +88,13 @@ func (p *ActorParser) parseCreate(rawParams, rawReturn []byte, msgCid cid.Cid) (
 	}
 	metadata[parser.ParamsKey] = params
 
-	createReturn, err := p.parseEamReturn(rawReturn, parser.MethodCreate)
+	createReturn, err := p.parseEamReturn(msgRct.Return, parser.MethodCreate)
 	if err != nil {
 		return metadata, nil, err
 	}
 	metadata[parser.ReturnKey] = p.newEamCreate(createReturn)
 
-	ethHash, err := ethtypes.EthHashFromCid(msgCid)
+	ethHash, err := ethtypes.EthHashFromCid(mainMsgCid)
 	if err != nil {
 		return metadata, nil, err
 	}
@@ -106,18 +106,20 @@ func (p *ActorParser) parseCreate(rawParams, rawReturn []byte, msgCid cid.Cid) (
 		Robust:        r.RobustAddress.String(),
 		EthAddress:    parser.EthPrefix + hex.EncodeToString(r.EthAddress[:]),
 		ActorType:     manifest.EvmKey,
-		CreationTxCid: msgCid.String(),
+		CreationTxCid: mainMsgCid.String(),
 	}
 
-	p.helper.GetActorsCache().StoreAddressInfo(*createdEvmActor)
+	if msgRct.ExitCode.IsSuccess() {
+		p.helper.GetActorsCache().StoreAddressInfo(*createdEvmActor)
+	}
 
 	return metadata, createdEvmActor, nil
 }
 
-func (p *ActorParser) parseCreate2(rawParams, rawReturn []byte, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
+func (p *ActorParser) parseCreate2(msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt, mainMsgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
 	metadata := make(map[string]interface{})
 
-	reader := bytes.NewReader(rawParams)
+	reader := bytes.NewReader(msg.Params)
 	var params eam.Create2Params
 	err := params.UnmarshalCBOR(reader)
 	if err != nil {
@@ -125,13 +127,13 @@ func (p *ActorParser) parseCreate2(rawParams, rawReturn []byte, msgCid cid.Cid) 
 	}
 	metadata[parser.ParamsKey] = params
 
-	createReturn, err := p.parseEamReturn(rawReturn, parser.MethodCreate2)
+	createReturn, err := p.parseEamReturn(msgRct.Return, parser.MethodCreate2)
 	if err != nil {
 		return metadata, nil, err
 	}
 	metadata[parser.ReturnKey] = p.newEamCreate(createReturn)
 
-	ethHash, err := ethtypes.EthHashFromCid(msgCid)
+	ethHash, err := ethtypes.EthHashFromCid(mainMsgCid)
 	if err != nil {
 		return metadata, nil, err
 	}
@@ -142,36 +144,38 @@ func (p *ActorParser) parseCreate2(rawParams, rawReturn []byte, msgCid cid.Cid) 
 		Robust:        r.RobustAddress.String(),
 		EthAddress:    parser.EthPrefix + hex.EncodeToString(r.EthAddress[:]),
 		ActorType:     manifest.EvmKey,
-		CreationTxCid: msgCid.String(),
+		CreationTxCid: mainMsgCid.String(),
 	}
 
-	p.helper.GetActorsCache().StoreAddressInfo(*createdEvmActor)
+	if msgRct.ExitCode.IsSuccess() {
+		p.helper.GetActorsCache().StoreAddressInfo(*createdEvmActor)
+	}
 
 	return metadata, createdEvmActor, nil
 }
 
-func (p *ActorParser) parseCreateExternal(rawParams, rawReturn []byte, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
+func (p *ActorParser) parseCreateExternal(msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt, mainMsgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
 	metadata := make(map[string]interface{})
-	reader := bytes.NewReader(rawParams)
-	metadata[parser.ParamsKey] = parser.EthPrefix + hex.EncodeToString(rawParams)
+	reader := bytes.NewReader(msg.Params)
+	metadata[parser.ParamsKey] = parser.EthPrefix + hex.EncodeToString(msg.Params)
 
 	var params abi.CborBytes
 	if err := params.UnmarshalCBOR(reader); err != nil {
 		_ = p.metrics.UpdateActorMethodErrorMetric(manifest.EamKey, parser.MethodCreateExternal)
-		p.logger.Warn(fmt.Sprintf("error deserializing rawParams: %s - hex data: %s", err.Error(), hex.EncodeToString(rawParams)))
+		p.logger.Warn(fmt.Sprintf("error deserializing rawParams: %s - hex data: %s", err.Error(), hex.EncodeToString(msg.Params)))
 	}
 
 	if reader.Len() == 0 { // This means that the reader has processed all the bytes
 		metadata[parser.ParamsKey] = parser.EthPrefix + hex.EncodeToString(params)
 	}
 
-	createExternalReturn, err := p.parseEamReturn(rawReturn, parser.MethodCreateExternal)
+	createExternalReturn, err := p.parseEamReturn(msgRct.Return, parser.MethodCreateExternal)
 	if err != nil {
 		return metadata, nil, err
 	}
 	metadata[parser.ReturnKey] = p.newEamCreate(createExternalReturn)
 
-	ethHash, err := ethtypes.EthHashFromCid(msgCid)
+	ethHash, err := ethtypes.EthHashFromCid(mainMsgCid)
 	if err != nil {
 		return metadata, nil, err
 	}
@@ -182,10 +186,12 @@ func (p *ActorParser) parseCreateExternal(rawParams, rawReturn []byte, msgCid ci
 		Robust:        r.RobustAddress.String(),
 		EthAddress:    parser.EthPrefix + hex.EncodeToString(r.EthAddress[:]),
 		ActorType:     manifest.EvmKey,
-		CreationTxCid: msgCid.String(),
+		CreationTxCid: mainMsgCid.String(),
 	}
 
-	p.helper.GetActorsCache().StoreAddressInfo(*createdEvmActor)
+	if msgRct.ExitCode.IsSuccess() {
+		p.helper.GetActorsCache().StoreAddressInfo(*createdEvmActor)
+	}
 
 	return metadata, createdEvmActor, nil
 }

--- a/actors/v1/power.go
+++ b/actors/v1/power.go
@@ -22,7 +22,7 @@ func (p *ActorParser) ParseStoragepower(txType string, msg *parser.LotusMessage,
 	case parser.MethodConstructor:
 		metadata, err = p.powerConstructor(msg.Params)
 	case parser.MethodCreateMiner, parser.MethodCreateMinerExported:
-		return p.parseCreateMiner(msg, msgRct.Return)
+		return p.parseCreateMiner(msg, msgRct)
 	case parser.MethodUpdateClaimedPower:
 		metadata, err = p.updateClaimedPower(msg.Params)
 	case parser.MethodEnrollCronEvent:
@@ -87,7 +87,7 @@ func (p *ActorParser) powerConstructor(raw []byte) (map[string]interface{}, erro
 	return metadata, nil
 }
 
-func (p *ActorParser) parseCreateMiner(msg *parser.LotusMessage, rawReturn []byte) (map[string]interface{}, *types.AddressInfo, error) {
+func (p *ActorParser) parseCreateMiner(msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt) (map[string]interface{}, *types.AddressInfo, error) {
 	metadata := make(map[string]interface{})
 	reader := bytes.NewReader(msg.Params)
 	var params power.CreateMinerParams
@@ -97,7 +97,7 @@ func (p *ActorParser) parseCreateMiner(msg *parser.LotusMessage, rawReturn []byt
 	}
 	metadata[parser.ParamsKey] = params
 
-	reader = bytes.NewReader(rawReturn)
+	reader = bytes.NewReader(msgRct.Return)
 	var r power.CreateMinerReturn
 	err = r.UnmarshalCBOR(reader)
 	if err != nil {
@@ -111,7 +111,9 @@ func (p *ActorParser) parseCreateMiner(msg *parser.LotusMessage, rawReturn []byt
 	}
 	metadata[parser.ReturnKey] = createdActor
 
-	p.helper.GetActorsCache().StoreAddressInfo(*createdActor)
+	if msgRct.ExitCode.IsSuccess() {
+		p.helper.GetActorsCache().StoreAddressInfo(*createdActor)
+	}
 
 	return metadata, createdActor, nil
 }

--- a/actors/v2/eam/create.go
+++ b/actors/v2/eam/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/ipfs/go-cid"
 
 	"github.com/zondax/fil-parser/actors"
@@ -11,17 +12,17 @@ import (
 	"github.com/zondax/fil-parser/types"
 )
 
-func (e *Eam) CreateExternal(network string, height int64, rawParams, rawReturn []byte, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
+func (e *Eam) CreateExternal(network string, height int64, rawParams, rawReturn []byte, ec exitcode.ExitCode, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
 	version := tools.VersionFromHeight(network, height)
 	params := abi.CborBytes{}
 	returnValue, ok := createExternalReturn[version.String()]
 	if !ok {
 		return nil, nil, fmt.Errorf("%w: %d", actors.ErrUnsupportedHeight, height)
 	}
-	return parseCreateExternal(e, rawParams, rawReturn, msgCid, params, returnValue(), e.helper)
+	return parseCreateExternal(e, rawParams, rawReturn, ec, msgCid, params, returnValue(), e.helper)
 }
 
-func (e *Eam) Create(network string, height int64, rawParams, rawReturn []byte, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
+func (e *Eam) Create(network string, height int64, rawParams, rawReturn []byte, ec exitcode.ExitCode, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
 	version := tools.VersionFromHeight(network, height)
 	params, ok := createParams[version.String()]
 	if !ok {
@@ -31,10 +32,10 @@ func (e *Eam) Create(network string, height int64, rawParams, rawReturn []byte, 
 	if !ok {
 		return nil, nil, fmt.Errorf("%w: %d", actors.ErrUnsupportedHeight, height)
 	}
-	return parseCreate(e, rawParams, rawReturn, msgCid, params(), returnValue(), e.helper)
+	return parseCreate(e, rawParams, rawReturn, ec, msgCid, params(), returnValue(), e.helper)
 }
 
-func (e *Eam) Create2(network string, height int64, rawParams, rawReturn []byte, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
+func (e *Eam) Create2(network string, height int64, rawParams, rawReturn []byte, ec exitcode.ExitCode, msgCid cid.Cid) (map[string]interface{}, *types.AddressInfo, error) {
 	version := tools.VersionFromHeight(network, height)
 	params, ok := create2Params[version.String()]
 	if !ok {
@@ -44,5 +45,5 @@ func (e *Eam) Create2(network string, height int64, rawParams, rawReturn []byte,
 	if !ok {
 		return nil, nil, fmt.Errorf("%w: %d", actors.ErrUnsupportedHeight, height)
 	}
-	return parseCreate(e, rawParams, rawReturn, msgCid, params(), returnValue(), e.helper)
+	return parseCreate(e, rawParams, rawReturn, ec, msgCid, params(), returnValue(), e.helper)
 }

--- a/actors/v2/eam/generic.go
+++ b/actors/v2/eam/generic.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zondax/fil-parser/parser/helper"
 
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/ipfs/go-cid"
 	"github.com/zondax/fil-parser/parser"
 	"github.com/zondax/fil-parser/types"
@@ -31,7 +32,7 @@ func parseEamReturn[R typegen.CBORUnmarshaler](rawReturn []byte, r R) (R, error)
 	return r, nil
 }
 
-func parseCreate[T typegen.CBORUnmarshaler, R typegen.CBORUnmarshaler](e *Eam, rawParams, rawReturn []byte, msgCid cid.Cid, params T, r R, h *helper.Helper) (map[string]interface{}, *types.AddressInfo, error) {
+func parseCreate[T typegen.CBORUnmarshaler, R typegen.CBORUnmarshaler](e *Eam, rawParams, rawReturn []byte, ec exitcode.ExitCode, msgCid cid.Cid, params T, r R, h *helper.Helper) (map[string]interface{}, *types.AddressInfo, error) {
 	metadata := make(map[string]interface{})
 	if len(rawParams) > 0 {
 		reader := bytes.NewReader(rawParams)
@@ -44,13 +45,13 @@ func parseCreate[T typegen.CBORUnmarshaler, R typegen.CBORUnmarshaler](e *Eam, r
 	}
 
 	if len(rawReturn) > 0 {
-		return handleReturnValue(e, rawReturn, metadata, msgCid, r, h)
+		return handleReturnValue(e, rawReturn, ec, metadata, msgCid, r, h)
 	}
 
 	return metadata, nil, nil
 }
 
-func parseCreateExternal[T typegen.CBORUnmarshaler](e *Eam, rawParams, rawReturn []byte, msgCid cid.Cid, params abi.CborBytes, r T, h *helper.Helper) (map[string]interface{}, *types.AddressInfo, error) {
+func parseCreateExternal[T typegen.CBORUnmarshaler](e *Eam, rawParams, rawReturn []byte, ec exitcode.ExitCode, msgCid cid.Cid, params abi.CborBytes, r T, h *helper.Helper) (map[string]interface{}, *types.AddressInfo, error) {
 	metadata := make(map[string]interface{})
 	if len(rawParams) > 0 {
 		reader := bytes.NewReader(rawParams)
@@ -66,12 +67,12 @@ func parseCreateExternal[T typegen.CBORUnmarshaler](e *Eam, rawParams, rawReturn
 	}
 
 	if len(rawReturn) > 0 {
-		return handleReturnValue(e, rawReturn, metadata, msgCid, r, h)
+		return handleReturnValue(e, rawReturn, ec, metadata, msgCid, r, h)
 	}
 	return metadata, nil, nil
 }
 
-func handleReturnValue[R typegen.CBORUnmarshaler](e *Eam, rawReturn []byte, metadata map[string]interface{}, msgCid cid.Cid, r R, h *helper.Helper) (map[string]interface{}, *types.AddressInfo, error) {
+func handleReturnValue[R typegen.CBORUnmarshaler](e *Eam, rawReturn []byte, ec exitcode.ExitCode, metadata map[string]interface{}, msgCid cid.Cid, r R, h *helper.Helper) (map[string]interface{}, *types.AddressInfo, error) {
 	createReturn, err := parseEamReturn(rawReturn, r)
 	if err != nil {
 		return nil, nil, err
@@ -84,7 +85,9 @@ func handleReturnValue[R typegen.CBORUnmarshaler](e *Eam, rawReturn []byte, meta
 	}
 	metadata[parser.EthHashKey] = ethHash
 
-	h.GetActorsCache().StoreAddressInfo(*createdEvmActor)
+	if ec.IsSuccess() {
+		h.GetActorsCache().StoreAddressInfo(*createdEvmActor)
+	}
 
 	return metadata, createdEvmActor, nil
 }

--- a/actors/v2/eam/parse.go
+++ b/actors/v2/eam/parse.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zondax/fil-parser/types"
 )
 
-func (p *Eam) Parse(_ context.Context, network string, height int64, txType string, msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt, msgCid cid.Cid, _ filTypes.TipSetKey) (map[string]interface{}, *types.AddressInfo, error) {
+func (p *Eam) Parse(_ context.Context, network string, height int64, txType string, msg *parser.LotusMessage, msgRct *parser.LotusMessageReceipt, mainMsgCid cid.Cid, _ filTypes.TipSetKey) (map[string]interface{}, *types.AddressInfo, error) {
 	metadata := make(map[string]interface{})
 	var err error
 	switch txType {
@@ -21,11 +21,11 @@ func (p *Eam) Parse(_ context.Context, network string, height int64, txType stri
 		resp, err := actors.ParseEmptyParamsAndReturn()
 		return resp, nil, err
 	case parser.MethodCreate:
-		return p.Create(network, height, msg.Params, msgRct.Return, msgCid)
+		return p.Create(network, height, msg.Params, msgRct.Return, msgRct.ExitCode, mainMsgCid)
 	case parser.MethodCreate2:
-		return p.Create2(network, height, msg.Params, msgRct.Return, msgCid)
+		return p.Create2(network, height, msg.Params, msgRct.Return, msgRct.ExitCode, mainMsgCid)
 	case parser.MethodCreateExternal:
-		return p.CreateExternal(network, height, msg.Params, msgRct.Return, msgCid)
+		return p.CreateExternal(network, height, msg.Params, msgRct.Return, msgRct.ExitCode, mainMsgCid)
 	case parser.UnknownStr:
 		resp, err := actors.ParseUnknownMetadata(msg.Params, msgRct.Return)
 		return resp, nil, err

--- a/actors/v2/init/init.go
+++ b/actors/v2/init/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	nonLegacyBuiltin "github.com/filecoin-project/go-state-types/builtin"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/manifest"
 	"github.com/filecoin-project/go-state-types/network"
 	filTypes "github.com/filecoin-project/lotus/chain/types"
@@ -103,7 +104,7 @@ func (*Init) Constructor(network string, height int64, raw []byte) (map[string]i
 	return initConstructor(raw, params())
 }
 
-func (i *Init) Exec(network string, height int64, msg *parser.LotusMessage, raw []byte) (map[string]interface{}, *types.AddressInfo, error) {
+func (i *Init) Exec(network string, height int64, msg *parser.LotusMessage, raw []byte, ec exitcode.ExitCode) (map[string]interface{}, *types.AddressInfo, error) {
 	version := tools.VersionFromHeight(network, height)
 	params, ok := execParams[version.String()]
 	if !ok {
@@ -120,18 +121,16 @@ func (i *Init) Exec(network string, height int64, msg *parser.LotusMessage, raw 
 		if err == nil {
 			addressInfo.ActorCid = createdActorCid.String()
 			addressInfo.ActorType = tools.ParseActorName(createdActorName)
-			// Store the address info in the actors cache
-			// if an actor is created and it's Constructor is called in the next execution,
-			// we will not be able to get the actor type without this.
-			// NOT needed for Exec4(evm) as this is done in eam.Create
-			i.helper.GetActorsCache().StoreAddressInfo(*addressInfo)
+			if ec.IsSuccess() {
+				i.helper.GetActorsCache().StoreAddressInfo(*addressInfo)
+			}
 		}
 	}
 
 	return metadata, addressInfo, err
 }
 
-func (i *Init) Exec4(network string, height int64, msg *parser.LotusMessage, raw []byte) (map[string]interface{}, *types.AddressInfo, error) {
+func (i *Init) Exec4(network string, height int64, msg *parser.LotusMessage, raw []byte, ec exitcode.ExitCode) (map[string]interface{}, *types.AddressInfo, error) {
 	version := tools.VersionFromHeight(network, height)
 	params, ok := exec4Params[version.String()]
 	if !ok {
@@ -148,6 +147,9 @@ func (i *Init) Exec4(network string, height int64, msg *parser.LotusMessage, raw
 		if err == nil {
 			addressInfo.ActorCid = createdActorCid.String()
 			addressInfo.ActorType = tools.ParseActorName(createdActorName)
+			if ec.IsSuccess() {
+				i.helper.GetActorsCache().StoreAddressInfo(*addressInfo)
+			}
 		}
 	}
 

--- a/actors/v2/init/parse.go
+++ b/actors/v2/init/parse.go
@@ -21,9 +21,9 @@ func (i *Init) Parse(_ context.Context, network string, height int64, txType str
 		resp, err := i.Constructor(network, height, msg.Params)
 		return resp, nil, err
 	case parser.MethodExec:
-		return i.Exec(network, height, msg, msgRct.Return)
+		return i.Exec(network, height, msg, msgRct.Return, msgRct.ExitCode)
 	case parser.MethodExec4:
-		return i.Exec4(network, height, msg, msgRct.Return)
+		return i.Exec4(network, height, msg, msgRct.Return, msgRct.ExitCode)
 	case parser.UnknownStr:
 		resp, err := actors.ParseUnknownMetadata(msg.Params, msgRct.Return)
 		return resp, nil, err

--- a/actors/v2/power/parse.go
+++ b/actors/v2/power/parse.go
@@ -21,7 +21,7 @@ func (p *Power) Parse(_ context.Context, network string, height int64, txType st
 	case parser.MethodConstructor:
 		metadata, err = p.Constructor(network, height, msg, msg.Params)
 	case parser.MethodCreateMiner, parser.MethodCreateMinerExported:
-		metadata, addressInfo, err = p.CreateMinerExported(network, msg, height, msg.Params, msgRct.Return)
+		metadata, addressInfo, err = p.CreateMinerExported(network, msg, height, msg.Params, msgRct.Return, msgRct.ExitCode)
 	case parser.MethodUpdateClaimedPower:
 		metadata, err = p.UpdateClaimedPower(network, msg, height, msg.Params, msgRct.Return)
 	case parser.MethodEnrollCronEvent:

--- a/actors/v2/power/power.go
+++ b/actors/v2/power/power.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	nonLegacyBuiltin "github.com/filecoin-project/go-state-types/builtin"
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-state-types/manifest"
 	"github.com/filecoin-project/go-state-types/proof"
 
@@ -140,7 +141,7 @@ func (*Power) Constructor(network string, height int64, msg *parser.LotusMessage
 	return parse(raw, nil, false, params(), &abi.EmptyValue{}, parser.ParamsKey)
 }
 
-func (p *Power) CreateMinerExported(network string, msg *parser.LotusMessage, height int64, raw, rawReturn []byte) (map[string]interface{}, *types.AddressInfo, error) {
+func (p *Power) CreateMinerExported(network string, msg *parser.LotusMessage, height int64, raw, rawReturn []byte, ec exitcode.ExitCode) (map[string]interface{}, *types.AddressInfo, error) {
 	version := tools.VersionFromHeight(network, height)
 	params, ok := createMinerParams[version.String()]
 	if !ok {
@@ -157,7 +158,7 @@ func (p *Power) CreateMinerExported(network string, msg *parser.LotusMessage, he
 		return nil, nil, err
 	}
 
-	if addressInfo != nil {
+	if ec.IsSuccess() && addressInfo != nil {
 		p.helper.GetActorsCache().StoreAddressInfo(*addressInfo)
 	}
 

--- a/parser/v1/parser.go
+++ b/parser/v1/parser.go
@@ -313,7 +313,7 @@ func (p *Parser) parseTrace(ctx context.Context, trace typesV1.ExecutionTraceV1,
 		_ = p.metrics.UpdateMetadataErrorMetric(actor, txType)
 		p.logger.Warnf("Could not get metadata for transaction in height %s of type '%s': %s", tipset.Height().String(), txType, mErr.Error())
 	}
-	if addressInfo != nil {
+	if trace.MsgRct.ExitCode.IsSuccess() && addressInfo != nil {
 		parser.AppendToAddressesMap(p.addresses, addressInfo)
 	}
 

--- a/parser/v2/parser.go
+++ b/parser/v2/parser.go
@@ -339,7 +339,7 @@ func (p *Parser) parseTrace(ctx context.Context, trace typesV2.ExecutionTraceV2,
 		p.logger.Errorf("Could not get metadata for transaction in height %s of type '%s': %s", tipset.Height().String(), txType, mErr.Error())
 	}
 
-	if addressInfo != nil {
+	if trace.MsgRct.ExitCode.IsSuccess() && addressInfo != nil {
 		parser.AppendToAddressesMap(p.addresses, addressInfo)
 	}
 	if metadata == nil {


### PR DESCRIPTION
Refactors actor parsing logic to utilize the message receipt and main message CID for EAM and Init actors.

Updates parsing functions to receive `msgRct` and `mainMsgCid` instead of individual parameters. This provides more context for parsing and improves code readability.

Additionally, it stores address info in the actor's cache only upon successful execution.


<!-- ClickUpRef: 8699gepkr -->
:link: [zboto Link](https://app.clickup.com/t/8699gepkr)