### PR TITLE
Fix: Use explicit height for blocks info parsing

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -413,7 +413,7 @@ func (p *FilecoinParser) ParseGenesisMultisig(ctx context.Context, genesis *type
 	return multisigInfos, nil
 }
 
-func (p *FilecoinParser) ParseBlocksInfo(ctx context.Context, trace []byte, metadata types.BlockMetadata, tipset *types.ExtendedTipSet) (*types.BlocksTimestamp, *types.AddressInfoMap, error) {
+func (p *FilecoinParser) ParseBlocksInfo(ctx context.Context, height uint64, trace []byte, metadata types.BlockMetadata, tipset *types.ExtendedTipSet) (*types.BlocksTimestamp, *types.AddressInfoMap, error) {
 	addresses := types.NewAddressInfoMap()
 	nodeFullVersion := parser.UnknownStr
 	nodeMajorMinorVersion := parser.UnknownStr
@@ -432,8 +432,7 @@ func (p *FilecoinParser) ParseBlocksInfo(ctx context.Context, trace []byte, meta
 		return &types.BlocksTimestamp{
 			TipsetBasicBlockData: types.TipsetBasicBlockData{
 				BasicBlockData: types.BasicBlockData{
-					// #nosec G115
-					Height:    uint64(tipset.Height()),
+					Height:    height,
 					TipsetCid: tipset.GetCidString(),
 				},
 				BlocksCid: []string{},
@@ -494,8 +493,7 @@ func (p *FilecoinParser) ParseBlocksInfo(ctx context.Context, trace []byte, meta
 	return &types.BlocksTimestamp{
 		TipsetBasicBlockData: types.TipsetBasicBlockData{
 			BasicBlockData: types.BasicBlockData{
-				// #nosec G115
-				Height:    uint64(tipset.Height()),
+				Height:    height,
 				TipsetCid: tipset.GetCidString(),
 			},
 			BlocksCid: blocksCid,


### PR DESCRIPTION
tipset.Height is 0 for tipsets with empty blocks

<!-- ClickUpRef: 8699jnu20 -->
:link: [zboto Link](https://app.clickup.com/t/8699jnu20)