### PR TITLE
Fix shortcidmap for local cache

### DIFF
--- a/actors/cache/impl/zcache.go
+++ b/actors/cache/impl/zcache.go
@@ -162,6 +162,14 @@ func (m *ZCache) initMapsLocalCache() error {
 	); err != nil {
 		return fmt.Errorf("error creating selectorHashSigMap for local zcache, err: %s", err)
 	}
+
+	if m.shortCidMap, err = zcache.NewLocalCache(&zcache.LocalConfig{
+		Prefix:       Short2CidMapPrefix,
+		Logger:       m.logger,
+		MetricServer: metrics2.NewNoopMetrics()},
+	); err != nil {
+		return fmt.Errorf("error creating shortCidMap for local zcache, err: %s", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
- When localCache is used there's a panic when trying to access the shortCidMap which is not initialized

<!-- ClickUpRef: 869akyv55 -->
:link: [zboto Link](https://app.clickup.com/t/869akyv55)