### PR TITLE
fix: bump rosetta-filecoin-lib to v1.3600.0-rc1 (close NV28 actor CID gap)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/whyrusleeping/cbor-gen v0.3.1
 	github.com/zondax/golem v0.29.0
-	github.com/zondax/rosetta-filecoin-lib v1.3401.0
+	github.com/zondax/rosetta-filecoin-lib v1.3600.0-rc1
 )
 
 require (
@@ -68,7 +68,7 @@ require (
 	gitlab.com/yawning/secp256k1-voi v0.0.0-20230925100816-f2616030848b // indirect
 	gitlab.com/yawning/tuplehash v0.0.0-20230713102510-df83abbf9a02 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.uber.org/zap v1.27.1 // indirect
+	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/tools v0.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -943,8 +943,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zondax/golem v0.29.0 h1:exAKRxX7ap5b9FuBLSFtPtdMkPBUqWV6h1DLN1m/pFg=
 github.com/zondax/golem v0.29.0/go.mod h1:MU2oVfrHeSg5d8oFvfuTKVddHebEXwgE/W24uPiRpWI=
-github.com/zondax/rosetta-filecoin-lib v1.3401.0 h1:LuXOodCIDqv1fNbj8BIvR8NElUPPfunHJ+MhvX2GHbI=
-github.com/zondax/rosetta-filecoin-lib v1.3401.0/go.mod h1:6JChv4NVcBYnGzR56WsQ0I+ymDsUkAUHJqPvuDVXyng=
+github.com/zondax/rosetta-filecoin-lib v1.3600.0-rc1 h1:VKSnnolf2xQonfs2HRiveDWLX8dYFUd2IbSCtBdtrMI=
+github.com/zondax/rosetta-filecoin-lib v1.3600.0-rc1/go.mod h1:9FbwFzashBX71P+GoePCtVI5xiwtCO852y/Kryk8jVs=
 gitlab.com/yawning/secp256k1-voi v0.0.0-20230925100816-f2616030848b h1:CzigHMRySiX3drau9C6Q5CAbNIApmLdat5jPMqChvDA=
 gitlab.com/yawning/secp256k1-voi v0.0.0-20230925100816-f2616030848b/go.mod h1:/y/V339mxv2sZmYYR64O07VuCpdNZqCTwO8ZcouTMI8=
 gitlab.com/yawning/tuplehash v0.0.0-20230713102510-df83abbf9a02 h1:qwDnMxjkyLmAFgcfgTnfJrmYKWhHnci3GjDqcZp1M3Q=
@@ -991,8 +991,8 @@ go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9E
 go.uber.org/zap v1.14.1/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
-go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
-go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+go.uber.org/zap v1.28.0 h1:IZzaP1Fv73/T/pBMLk4VutPl36uNC+OSUh3JLG3FIjo=
+go.uber.org/zap v1.28.0/go.mod h1:rDLpOi171uODNm/mxFcuYWxDsqWSAVkFdX4XojSKg/Q=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=


### PR DESCRIPTION
## Summary

\`v4.3600.0-rc1\` (NV28 / FireHorse) shipped with \`rosetta-filecoin-lib\` pinned at \`v1.3401.0\`, which has \`LatestVersion = network.Version27\`. The actor CID loader (\`actors/actors.go\`) iterates \`V0..LatestVersion\` and queries \`StateActorCodeCIDs\` per version — so **NV28 actor code CIDs are never loaded into the registry**.

\`rosetta-filecoin-lib v1.3600.0-rc1\` (published 2026-05-05, ~15h before \`fil-parser v4.3600.0-rc1\`) raises \`LatestVersion\` to \`network.Version28\` and pins \`lotus v1.36.0-rc1\`. The dep just needs to be bumped here.

## Observed symptom on calibration-blue (pro-zur1, v9.0.2-rc1 + parser v4.3600.0-rc1)

\`\`\`
ERROR helper/helpers.go:212 — could not get actor cid and name from address.
  Err: invalid actor code CID: bafk2bzaceb63lj5qyx6hrtagl4mlqla6rb2ligpeglurhfvn2avubim62oyxc
\`\`\`

Metric counters ticking:
- \`fil_parser_helper_actor_name_error{code="3844450837"}\` — that's FRC-42 of \`InvokeContract\`
- \`fil_parser_parser_parse_tx_metadata_error{txType="Constructor", mainSuccess="true", subcallSuccess="true"}\`

\`txType=Constructor\` here is the catch-all label assigned when the parser can't classify the actor — the underlying cause is the unknown CID, not Constructor decoding per se.

## Change

- \`go.mod\`: \`zondax/rosetta-filecoin-lib v1.3401.0\` → \`v1.3600.0-rc1\`
- \`go mod tidy\` lifted \`go.uber.org/zap v1.27.1\` → \`v1.28.0\` (indirect)

## Test plan

- [x] \`GOTOOLCHAIN=go1.25.7 go build ./...\` clean
- [x] \`go test -short ./...\` — same outcome as v4.3600.0-rc1 baseline (one pre-existing test failure \`TestParser_ParseTransactions\` "Rosetta lib should not be nil" present on both, unrelated to this bump)
- [ ] CI green
- [ ] After merge: tag \`v4.3600.1-rc1\` (pre-release), bump in fil-indexing, deploy to indexing-calibration-blue, verify both \`fil_parser_helper_actor_name_error\` and \`fil_parser_parser_parse_tx_metadata_error\` stop ticking on the unrecognized CIDs

## Notes for the release

This is a single-line dep bump. After merge → tag from the merge commit on \`dev\` as \`v4.3600.1-rc1\` (pre-release, between rc1 and the next rc).